### PR TITLE
フロントエンドの配色を白ベースに変更

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,846 @@
+{
+  "name": "ixv-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ixv-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "^4.19.2",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>IXV Dashboard</title>
   </head>
-  <body class="bg-slate-950 text-slate-100">
+  <body class="bg-bg-base text-text-base">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,6 @@
       "version": "7.28.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1255,7 +1254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1594,7 +1592,6 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -1795,7 +1792,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1949,7 +1945,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2233,7 +2228,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2295,7 +2289,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -91,7 +91,7 @@ export default function App() {
           </div>
           <div className="flex items-center gap-3">
             <button
-              className={`text-xs px-2 py-1 rounded border ${demoMode ? "border-primary bg-primary-light" : "border-border-default hover:bg-bg-hover"}`}
+              className="text-xs px-2 py-1 rounded border border-primary bg-primary text-white hover:bg-primary-dark"
               onClick={() => setDemoMode((d) => !d)}
               title="デモモード切替"
             >

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -82,54 +82,54 @@ export default function App() {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
-      <header className="px-6 py-5 border-b border-slate-800">
+    <div className="min-h-screen bg-bg-base">
+      <header className="px-6 py-5 border-b border-border-default">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-semibold">IXV-Agents Dashboard</h1>
-            <p className="text-slate-400 text-sm">Read-only status view</p>
+            <p className="text-text-muted text-sm">Read-only status view</p>
           </div>
           <div className="flex items-center gap-3">
             <button
-              className={`text-xs px-2 py-1 rounded border ${demoMode ? "border-emerald-600 bg-emerald-950/40" : "border-slate-700 hover:bg-slate-800"}`}
+              className={`text-xs px-2 py-1 rounded border ${demoMode ? "border-accent bg-accent/10" : "border-border-default hover:bg-bg-hover"}`}
               onClick={() => setDemoMode((d) => !d)}
               title="デモモード切替"
             >
               {demoMode ? "デモモード" : "ライブモード"}
             </button>
             {demoMode && (
-              <div className="text-xs text-slate-400">デモデータ表示中</div>
+              <div className="text-xs text-text-muted">デモデータ表示中</div>
             )}
           </div>
         </div>
       </header> 
       <main className="grid gap-6 p-6 lg:grid-cols-3 xl:grid-cols-4">
-        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        <section className="rounded-lg border border-border-default bg-bg-surface p-4">
           <h2 className="text-lg font-semibold mb-3">Dashboard</h2>
-          <pre className="whitespace-pre-wrap text-sm text-slate-200">
+          <pre className="whitespace-pre-wrap text-sm text-text-base">
             {dashboard}
           </pre>
         </section>
-        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        <section className="rounded-lg border border-border-default bg-bg-surface p-4">
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-lg font-semibold">Queue Overview</h2>
             <button
-              className="text-xs px-2 py-1 rounded border border-slate-700 hover:bg-slate-800"
+              className="text-xs px-2 py-1 rounded border border-border-default hover:bg-bg-hover"
               onClick={loadData}
             >
               Refresh
             </button>
           </div>
-          <div className="text-xs text-slate-400 mb-4">
+          <div className="text-xs text-text-muted mb-4">
             Last updated: {lastUpdated ? lastUpdated.toLocaleTimeString() : "-"}
           </div>
           <div className="space-y-4 text-sm">
             <div>
               <div className="font-semibold">PO → SM</div>
-              <div className="text-slate-300">
+              <div className="text-text-secondary">
                 {queue?.po_to_sm?.data?.summary || "No summary"}
               </div>
-              <div className="text-xs text-slate-500">
+              <div className="text-xs text-text-muted">
                 {queue?.po_to_sm?.file} · {queue?.po_to_sm?.mtime || "-"}
               </div>
             </div>
@@ -137,7 +137,7 @@ export default function App() {
               <div className="font-semibold">Tasks</div>
               <div className="grid gap-2">
                 {tasks.length === 0 && (
-                  <div className="text-slate-500">No tasks</div>
+                  <div className="text-text-muted">No tasks</div>
                 )}
                 {tasks.map((t) => (
                   <button
@@ -145,17 +145,17 @@ export default function App() {
                     onClick={() => setSelectedTaskId(t.data?.task_id || "")}
                     className={`text-left rounded border px-2 py-2 ${
                       t.data?.task_id === selectedTaskId
-                        ? "border-emerald-600 bg-emerald-950/40"
-                        : "border-slate-800 hover:bg-slate-800/60"
+                        ? "border-accent bg-accent/10"
+                        : "border-border-default hover:bg-bg-hover"
                     }`}
                   >
                     <div className="font-medium">
                       {t.data?.task_id || t.file}
                     </div>
-                    <div className="text-xs text-slate-400">
+                    <div className="text-xs text-text-muted">
                       {t.data?.assignee || "-"} · {t.mtime}
                     </div>
-                    <div className="text-slate-300 text-xs">
+                    <div className="text-text-secondary text-xs">
                       {t.data?.summary || "-"}
                     </div>
                   </button>
@@ -164,38 +164,38 @@ export default function App() {
             </div>
             <div>
               <div className="font-semibold">Reports</div>
-              <div className="text-xs text-slate-400">
+              <div className="text-xs text-text-muted">
                 {reports.length} files
               </div>
             </div>
           </div>
         </section>
-        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        <section className="rounded-lg border border-border-default bg-bg-surface p-4">
           <h2 className="text-lg font-semibold mb-3">Task Detail</h2>
           {!selectedTask && (
-            <div className="text-sm text-slate-400">No task selected</div>
+            <div className="text-sm text-text-muted">No task selected</div>
           )}
           {selectedTask && (
             <div className="space-y-3 text-sm">
               <div>
-                <div className="text-slate-400 text-xs">Task ID</div>
+                <div className="text-text-muted text-xs">Task ID</div>
                 <div>{selectedTask.data?.task_id || "-"}</div>
               </div>
               <div>
-                <div className="text-slate-400 text-xs">Assignee</div>
+                <div className="text-text-muted text-xs">Assignee</div>
                 <div>{selectedTask.data?.assignee || "-"}</div>
               </div>
               <div>
-                <div className="text-slate-400 text-xs">Type</div>
+                <div className="text-text-muted text-xs">Type</div>
                 <div>{selectedTask.data?.type || "-"}</div>
               </div>
               <div>
-                <div className="text-slate-400 text-xs">Summary</div>
+                <div className="text-text-muted text-xs">Summary</div>
                 <div>{selectedTask.data?.summary || "-"}</div>
               </div>
               <div>
-                <div className="text-slate-400 text-xs">Definition of Done</div>
-                <ul className="list-disc list-inside text-slate-300">
+                <div className="text-text-muted text-xs">Definition of Done</div>
+                <ul className="list-disc list-inside text-text-secondary">
                   {(selectedTask.data?.definition_of_done || []).map(
                     (item, idx) => (
                       <li key={idx}>{item}</li>
@@ -204,12 +204,12 @@ export default function App() {
                 </ul>
               </div>
               <div>
-                <div className="text-slate-400 text-xs">Report Status</div>
+                <div className="text-text-muted text-xs">Report Status</div>
                 <div>{matchedReport?.data?.status || "-"}</div>
               </div>
               <div>
-                <div className="text-slate-400 text-xs">Artifacts</div>
-                <ul className="list-disc list-inside text-slate-300">
+                <div className="text-text-muted text-xs">Artifacts</div>
+                <ul className="list-disc list-inside text-text-secondary">
                   {(matchedReport?.data?.artifacts || []).map((item, idx) => (
                     <li key={idx}>{item}</li>
                   ))}
@@ -218,10 +218,10 @@ export default function App() {
             </div>
           )}
         </section>
-        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        <section className="rounded-lg border border-border-default bg-bg-surface p-4">
           <Events apiBase={API_BASE} demoMode={demoMode} />
         </section>
-        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        <section className="rounded-lg border border-border-default bg-bg-surface p-4">
           <TerminalStream apiBase={API_BASE} demoMode={demoMode} />
         </section>
       </main>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -83,7 +83,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-bg-base">
-      <header className="px-6 py-5 border-b border-border-default">
+      <header className="px-6 py-5 border-b border-border-default bg-bg-surface">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-semibold">IXV-Agents Dashboard</h1>
@@ -91,7 +91,7 @@ export default function App() {
           </div>
           <div className="flex items-center gap-3">
             <button
-              className={`text-xs px-2 py-1 rounded border ${demoMode ? "border-accent bg-accent/10" : "border-border-default hover:bg-bg-hover"}`}
+              className={`text-xs px-2 py-1 rounded border ${demoMode ? "border-primary bg-primary-light" : "border-border-default hover:bg-bg-hover"}`}
               onClick={() => setDemoMode((d) => !d)}
               title="デモモード切替"
             >
@@ -145,7 +145,7 @@ export default function App() {
                     onClick={() => setSelectedTaskId(t.data?.task_id || "")}
                     className={`text-left rounded border px-2 py-2 ${
                       t.data?.task_id === selectedTaskId
-                        ? "border-accent bg-accent/10"
+                        ? "border-primary bg-primary-light"
                         : "border-border-default hover:bg-bg-hover"
                     }`}
                   >

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -86,7 +86,7 @@ export default function App() {
       <header className="px-6 py-5 border-b border-border-default bg-bg-surface">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold">IXV-Agents Dashboard</h1>
+            <h1 className="text-2xl font-semibold text-primary">IXV-Agents Dashboard</h1>
             <p className="text-text-muted text-sm">Read-only status view</p>
           </div>
           <div className="flex items-center gap-3">

--- a/frontend/src/Events.jsx
+++ b/frontend/src/Events.jsx
@@ -82,21 +82,21 @@ export default function Events({ apiBase = "", demoMode = false }) {
         <h2 className="text-lg font-semibold">Agent Events (real-time)</h2>
         <div className="flex items-center gap-2">
           <button
-            className="text-xs px-2 py-1 rounded border border-slate-700 hover:bg-slate-800"
+            className="text-xs px-2 py-1 rounded border border-border-default hover:bg-bg-hover"
             onClick={() => (runningRef.current = true)}
             title="Resume events"
           >
             Resume
           </button>
           <button
-            className="text-xs px-2 py-1 rounded border border-slate-700 hover:bg-slate-800"
+            className="text-xs px-2 py-1 rounded border border-border-default hover:bg-bg-hover"
             onClick={() => (runningRef.current = false)}
             title="Pause events"
           >
             Pause
           </button>
           <button
-            className="text-xs px-2 py-1 rounded border border-slate-700 hover:bg-slate-800"
+            className="text-xs px-2 py-1 rounded border border-border-default hover:bg-bg-hover"
             onClick={() => setEvents([])}
             title="Clear events"
           >
@@ -107,7 +107,7 @@ export default function Events({ apiBase = "", demoMode = false }) {
 
       <div className="grid grid-cols-2 gap-2 mb-3">
         {Object.keys(agentStatus).length === 0 && (
-          <div className="col-span-2 text-slate-500 text-sm">
+          <div className="col-span-2 text-text-muted text-sm">
             No agent activity yet
           </div>
         )}
@@ -116,18 +116,18 @@ export default function Events({ apiBase = "", demoMode = false }) {
           return (
             <div
               key={agent}
-              className={`rounded border border-slate-800 bg-slate-900/60 p-2 ${
+              className={`rounded border border-border-default bg-bg-muted p-2 ${
                 isHot ? "ixv-flash" : ""
               }`}
             >
               <div className="flex items-center justify-between">
                 <div className="font-medium">{agent}</div>
-                <div className={`h-2 w-2 rounded-full bg-emerald-400 ${isHot ? "ixv-ping" : ""}`} />
+                <div className={`h-2 w-2 rounded-full bg-accent ${isHot ? "ixv-ping" : ""}`} />
               </div>
-              <div className="text-xs text-slate-400 mt-1">
+              <div className="text-xs text-text-muted mt-1">
                 {new Date(data.ts).toLocaleTimeString()}
               </div>
-              <div className="text-slate-300 text-xs mt-1">
+              <div className="text-text-secondary text-xs mt-1">
                 {data.message || "-"}
               </div>
             </div>
@@ -135,9 +135,9 @@ export default function Events({ apiBase = "", demoMode = false }) {
         })}
       </div>
 
-      <div className="h-64 overflow-y-auto bg-slate-900/50 p-2 rounded">
+      <div className="h-64 overflow-y-auto bg-bg-muted p-2 rounded">
         {events.length === 0 && (
-          <div className="text-slate-500 text-sm">No events yet</div>
+          <div className="text-text-muted text-sm">No events yet</div>
         )}
         <ul className="space-y-2 text-sm">
           {events.map((ev) => {
@@ -145,15 +145,15 @@ export default function Events({ apiBase = "", demoMode = false }) {
             return (
               <li
                 key={ev.id}
-                className={`rounded border border-slate-800 p-2 ${
+                className={`rounded border border-border-default bg-bg-surface p-2 ${
                   isFresh ? "ixv-flash" : ""
                 }`}
               >
               <div className="flex items-baseline justify-between">
                 <div className="font-medium">{ev.agent}</div>
-                <div className="text-xs text-slate-400">{new Date(ev.ts).toLocaleTimeString()}</div>
+                <div className="text-xs text-text-muted">{new Date(ev.ts).toLocaleTimeString()}</div>
               </div>
-              <div className="text-slate-300 text-sm">{ev.message}</div>
+              <div className="text-text-secondary text-sm">{ev.message}</div>
               </li>
             );
           })}

--- a/frontend/src/Events.jsx
+++ b/frontend/src/Events.jsx
@@ -122,7 +122,7 @@ export default function Events({ apiBase = "", demoMode = false }) {
             >
               <div className="flex items-center justify-between">
                 <div className="font-medium">{agent}</div>
-                <div className={`h-2 w-2 rounded-full bg-accent ${isHot ? "ixv-ping" : ""}`} />
+                <div className={`h-2 w-2 rounded-full bg-primary ${isHot ? "ixv-ping" : ""}`} />
               </div>
               <div className="text-xs text-text-muted mt-1">
                 {new Date(data.ts).toLocaleTimeString()}

--- a/frontend/src/Events.jsx
+++ b/frontend/src/Events.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 export default function Events({ apiBase = "", demoMode = false }) {
   const [events, setEvents] = useState([]);
   const [agentStatus, setAgentStatus] = useState({});
+  const [isRunning, setIsRunning] = useState(true);
   const runningRef = useRef(true);
   const esRef = useRef(null);
 
@@ -82,15 +83,31 @@ export default function Events({ apiBase = "", demoMode = false }) {
         <h2 className="text-lg font-semibold">Agent Events (real-time)</h2>
         <div className="flex items-center gap-2">
           <button
-            className="text-xs px-2 py-1 rounded border border-border-default hover:bg-bg-hover"
-            onClick={() => (runningRef.current = true)}
+            className={`text-xs px-2 py-1 rounded border ${
+              isRunning
+                ? "border-border-default text-text-muted cursor-not-allowed"
+                : "border-accent bg-accent text-black hover:bg-accent-dark"
+            }`}
+            onClick={() => {
+              runningRef.current = true;
+              setIsRunning(true);
+            }}
+            disabled={isRunning}
             title="Resume events"
           >
             Resume
           </button>
           <button
-            className="text-xs px-2 py-1 rounded border border-border-default hover:bg-bg-hover"
-            onClick={() => (runningRef.current = false)}
+            className={`text-xs px-2 py-1 rounded border ${
+              !isRunning
+                ? "border-border-default text-text-muted cursor-not-allowed"
+                : "border-accent bg-accent text-black hover:bg-accent-dark"
+            }`}
+            onClick={() => {
+              runningRef.current = false;
+              setIsRunning(false);
+            }}
+            disabled={!isRunning}
             title="Pause events"
           >
             Pause

--- a/frontend/src/TerminalStream.jsx
+++ b/frontend/src/TerminalStream.jsx
@@ -90,13 +90,13 @@ export default function TerminalStream({ apiBase = "", demoMode = false }) {
     <div>
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-lg font-semibold">ターミナル活動</h2>
-        <div className="text-xs text-slate-400">
+        <div className="text-xs text-text-muted">
           {demoMode ? "デモストリーム" : "tmux ライブストリーム"}
         </div>
       </div>
 
       {items.length === 0 && (
-        <div className="text-slate-500 text-sm">ターミナル出力を待機中…</div>
+        <div className="text-text-muted text-sm">ターミナル出力を待機中…</div>
       )}
 
       <div className="space-y-3">
@@ -105,17 +105,17 @@ export default function TerminalStream({ apiBase = "", demoMode = false }) {
           return (
             <div
               key={pane.pane || pane.paneId || "system"}
-              className={`rounded border border-slate-800 bg-slate-900/60 p-2 ${
+              className={`rounded border border-border-default bg-bg-muted p-2 ${
                 isHot ? "ixv-flash" : ""
               }`}
             >
               <div className="flex items-center justify-between mb-1">
                 <div className="font-medium">{pane.pane || "system"}</div>
-                <div className="text-xs text-slate-400">
+                <div className="text-xs text-text-muted">
                   {pane.ts ? new Date(pane.ts).toLocaleTimeString() : "-"}
                 </div>
               </div>
-              <pre className="text-xs text-slate-300 whitespace-pre-wrap">
+              <pre className="text-xs text-text-secondary whitespace-pre-wrap">
                 {(pane.lines || []).map(localizeLine).join("\n")}
               </pre>
             </div>

--- a/frontend/src/TerminalStream.jsx
+++ b/frontend/src/TerminalStream.jsx
@@ -115,7 +115,7 @@ export default function TerminalStream({ apiBase = "", demoMode = false }) {
                   {pane.ts ? new Date(pane.ts).toLocaleTimeString() : "-"}
                 </div>
               </div>
-              <pre className="text-xs text-text-secondary whitespace-pre-wrap">
+              <pre className="text-xs text-text-secondary whitespace-pre-wrap overflow-x-auto">
                 {(pane.lines || []).map(localizeLine).join("\n")}
               </pre>
             </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3,24 +3,49 @@
 @tailwind utilities;
 
 :root {
-  /* 背景色 */
-  --color-bg-base: 255 255 255;        /* white - ページ全体の背景 */
-  --color-bg-surface: 248 250 252;     /* slate-50 - カード等の背景 */
-  --color-bg-muted: 241 245 249;       /* slate-100 - 控えめな背景 */
-  --color-bg-hover: 226 232 240;       /* slate-200 - ホバー時の背景 */
+  /* 背景色 (gray パレット - coding-policy-ai-auditor準拠) */
+  --color-bg-base: 243 244 246;        /* gray-100 - ページ全体の背景 */
+  --color-bg-surface: 255 255 255;     /* white - カード等の背景 */
+  --color-bg-muted: 249 250 251;       /* gray-50 - 控えめな背景 */
+  --color-bg-hover: 229 231 235;       /* gray-200 - ホバー時の背景 */
 
-  /* テキスト色 */
-  --color-text-base: 15 23 42;         /* slate-900 - メインテキスト */
-  --color-text-secondary: 71 85 105;   /* slate-500 - セカンダリテキスト */
-  --color-text-muted: 148 163 184;     /* slate-400 - 控えめなテキスト */
+  /* テキスト色 (gray パレット) */
+  --color-text-base: 17 24 39;         /* gray-900 - メインテキスト */
+  --color-text-strong: 31 41 55;       /* gray-800 - 強調テキスト */
+  --color-text-default: 55 65 81;      /* gray-700 - 通常テキスト */
+  --color-text-secondary: 107 114 128; /* gray-500 - セカンダリテキスト */
+  --color-text-muted: 156 163 175;     /* gray-400 - 控えめなテキスト */
 
-  /* ボーダー色 */
-  --color-border: 226 232 240;         /* slate-200 - 通常ボーダー */
-  --color-border-muted: 241 245 249;   /* slate-100 - 控えめなボーダー */
+  /* ボーダー色 (gray パレット) */
+  --color-border: 229 231 235;         /* gray-200 - 通常ボーダー */
+  --color-border-strong: 209 213 219;  /* gray-300 - 強調ボーダー */
+  --color-border-muted: 243 244 246;   /* gray-100 - 控えめなボーダー */
 
-  /* アクセント色 */
-  --color-accent: 16 185 129;          /* emerald-500 */
-  --color-accent-muted: 6 78 59;       /* emerald-900 - アクセント背景用 */
+  /* プライマリ色 (blue - リンク、主要ボタン) */
+  --color-primary: 63 97 167;          /* #3F61A7 - ベース */
+  --color-primary-hover: 29 78 216;    /* blue-700 - ホバー時 */
+  --color-primary-light: 219 234 254;  /* blue-100 - 背景用 */
+  --color-primary-ring: 59 130 246;    /* blue-500 - フォーカスリング */
+
+  /* アクセント色 (yellow - 選択状態等) */
+  --color-accent: 255 211 45;          /* #FFD32D - ベース */
+  --color-accent-hover: 234 179 8;     /* yellow-500 - ホバー時 */
+  --color-accent-light: 254 249 195;   /* yellow-100 - 背景用 */
+
+  /* ステータス色 - 成功 (green) */
+  --color-success: 22 163 74;          /* green-600 */
+  --color-success-hover: 21 128 61;    /* green-700 */
+  --color-success-light: 220 252 231;  /* green-100 */
+
+  /* ステータス色 - 警告 (yellow) */
+  --color-warning: 202 138 4;          /* yellow-600 */
+  --color-warning-hover: 161 98 7;     /* yellow-700 */
+  --color-warning-light: 254 249 195;  /* yellow-100 */
+
+  /* ステータス色 - エラー (red) */
+  --color-danger: 220 38 38;           /* red-600 */
+  --color-danger-hover: 185 28 28;     /* red-700 */
+  --color-danger-light: 254 226 226;   /* red-100 */
 }
 
 body {
@@ -40,21 +65,21 @@ body {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid rgba(16, 185, 129, 0.6);
+  border: 1px solid rgba(63, 97, 167, 0.6);
   animation: ixvPing 1.2s ease-out infinite;
 }
 
 @keyframes ixvFlash {
   0% {
-    box-shadow: 0 0 0 rgba(16, 185, 129, 0.8);
+    box-shadow: 0 0 0 rgba(63, 97, 167, 0.8);
     transform: translateY(0);
   }
   40% {
-    box-shadow: 0 0 20px rgba(16, 185, 129, 0.6);
+    box-shadow: 0 0 20px rgba(63, 97, 167, 0.6);
     transform: translateY(-2px);
   }
   100% {
-    box-shadow: 0 0 0 rgba(16, 185, 129, 0);
+    box-shadow: 0 0 0 rgba(63, 97, 167, 0);
     transform: translateY(0);
   }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2,6 +2,27 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  /* 背景色 */
+  --color-bg-base: 255 255 255;        /* white - ページ全体の背景 */
+  --color-bg-surface: 248 250 252;     /* slate-50 - カード等の背景 */
+  --color-bg-muted: 241 245 249;       /* slate-100 - 控えめな背景 */
+  --color-bg-hover: 226 232 240;       /* slate-200 - ホバー時の背景 */
+
+  /* テキスト色 */
+  --color-text-base: 15 23 42;         /* slate-900 - メインテキスト */
+  --color-text-secondary: 71 85 105;   /* slate-500 - セカンダリテキスト */
+  --color-text-muted: 148 163 184;     /* slate-400 - 控えめなテキスト */
+
+  /* ボーダー色 */
+  --color-border: 226 232 240;         /* slate-200 - 通常ボーダー */
+  --color-border-muted: 241 245 249;   /* slate-100 - 控えめなボーダー */
+
+  /* アクセント色 */
+  --color-accent: 16 185 129;          /* emerald-500 */
+  --color-accent-muted: 6 78 59;       /* emerald-900 - アクセント背景用 */
+}
+
 body {
   font-family: "Space Grotesk", system-ui, sans-serif;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,14 +10,35 @@ export default {
         "bg-hover": "rgb(var(--color-bg-hover) / <alpha-value>)",
         // テキスト色
         "text-base": "rgb(var(--color-text-base) / <alpha-value>)",
+        "text-strong": "rgb(var(--color-text-strong) / <alpha-value>)",
+        "text-default": "rgb(var(--color-text-default) / <alpha-value>)",
         "text-secondary": "rgb(var(--color-text-secondary) / <alpha-value>)",
         "text-muted": "rgb(var(--color-text-muted) / <alpha-value>)",
         // ボーダー色
         "border-default": "rgb(var(--color-border) / <alpha-value>)",
+        "border-strong": "rgb(var(--color-border-strong) / <alpha-value>)",
         "border-muted": "rgb(var(--color-border-muted) / <alpha-value>)",
-        // アクセント色
+        // プライマリ色 (リンク、主要ボタン)
+        "primary": "rgb(var(--color-primary) / <alpha-value>)",
+        "primary-hover": "rgb(var(--color-primary-hover) / <alpha-value>)",
+        "primary-light": "rgb(var(--color-primary-light) / <alpha-value>)",
+        "primary-ring": "rgb(var(--color-primary-ring) / <alpha-value>)",
+        // アクセント色 (選択状態等)
         "accent": "rgb(var(--color-accent) / <alpha-value>)",
-        "accent-muted": "rgb(var(--color-accent-muted) / <alpha-value>)",
+        "accent-hover": "rgb(var(--color-accent-hover) / <alpha-value>)",
+        "accent-light": "rgb(var(--color-accent-light) / <alpha-value>)",
+        // ステータス色 - 成功
+        "success": "rgb(var(--color-success) / <alpha-value>)",
+        "success-hover": "rgb(var(--color-success-hover) / <alpha-value>)",
+        "success-light": "rgb(var(--color-success-light) / <alpha-value>)",
+        // ステータス色 - 警告
+        "warning": "rgb(var(--color-warning) / <alpha-value>)",
+        "warning-hover": "rgb(var(--color-warning-hover) / <alpha-value>)",
+        "warning-light": "rgb(var(--color-warning-light) / <alpha-value>)",
+        // ステータス色 - エラー
+        "danger": "rgb(var(--color-danger) / <alpha-value>)",
+        "danger-hover": "rgb(var(--color-danger-hover) / <alpha-value>)",
+        "danger-light": "rgb(var(--color-danger-light) / <alpha-value>)",
       }
     }
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,7 +1,25 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        // 背景色
+        "bg-base": "rgb(var(--color-bg-base) / <alpha-value>)",
+        "bg-surface": "rgb(var(--color-bg-surface) / <alpha-value>)",
+        "bg-muted": "rgb(var(--color-bg-muted) / <alpha-value>)",
+        "bg-hover": "rgb(var(--color-bg-hover) / <alpha-value>)",
+        // テキスト色
+        "text-base": "rgb(var(--color-text-base) / <alpha-value>)",
+        "text-secondary": "rgb(var(--color-text-secondary) / <alpha-value>)",
+        "text-muted": "rgb(var(--color-text-muted) / <alpha-value>)",
+        // ボーダー色
+        "border-default": "rgb(var(--color-border) / <alpha-value>)",
+        "border-muted": "rgb(var(--color-border-muted) / <alpha-value>)",
+        // アクセント色
+        "accent": "rgb(var(--color-accent) / <alpha-value>)",
+        "accent-muted": "rgb(var(--color-accent-muted) / <alpha-value>)",
+      }
+    }
   },
   plugins: []
 };

--- a/scripts/ixv_boot.sh
+++ b/scripts/ixv_boot.sh
@@ -39,7 +39,7 @@ tmux kill-session -t ixv-dev 2>/dev/null || true
 tmux kill-session -t ixv-qa 2>/dev/null || true
 
 log "Creating ixv-management session (PO/SM)..."
-tmux new-session -d -s ixv-management -n "management"
+tmux new-session -d -s ixv-management -n "management" -x 200 -y 50
 tmux split-window -v -t "ixv-management:0"
 tmux select-pane -t "ixv-management:0.0" -T "PO"
 tmux select-pane -t "ixv-management:0.1" -T "SM"
@@ -47,7 +47,7 @@ tmux send-keys -t "ixv-management:0.0" "cd $ROOT_DIR && export PS1='(PO) \\w\\$ 
 tmux send-keys -t "ixv-management:0.1" "cd $ROOT_DIR && export PS1='(SM) \\w\\$ ' && clear" Enter
 
 log "Creating ixv-dev session (Dev1-Dev8)..."
-tmux new-session -d -s ixv-dev -n "dev"
+tmux new-session -d -s ixv-dev -n "dev" -x 200 -y 50
 tmux split-window -h -t "ixv-dev:0"
 tmux split-window -h -t "ixv-dev:0"
 tmux split-window -h -t "ixv-dev:0"
@@ -64,7 +64,7 @@ for i in {0..7}; do
 done
 
 log "Creating ixv-qa session (QA1-QA2)..."
-tmux new-session -d -s ixv-qa -n "qa"
+tmux new-session -d -s ixv-qa -n "qa" -x 200 -y 50
 tmux split-window -v -t "ixv-qa:0"
 tmux select-pane -t "ixv-qa:0.0" -T "QA1"
 tmux select-pane -t "ixv-qa:0.1" -T "QA2"
@@ -82,6 +82,21 @@ if [ "$SETUP_ONLY" = false ]; then
   tmux send-keys -t "ixv-qa:0.1" "claude --dangerously-skip-permissions" Enter
 
   sleep 8
+
+  # Claude Code起動時にターミナルタイトルが「Claude Code」に上書きされる。
+  # フロントエンドはペインタイトルをキーとして表示するため、
+  # 全ペインが同じタイトルだと1件に集約されてしまう。
+  # そのため、Claude Code起動完了後にタイトルを再設定する。
+  # FIXME: ターミナルタイトルに依存しない方式に変更する
+  log "Re-setting pane titles (after Claude Code overwrites them)..."
+  tmux select-pane -t "ixv-management:0.0" -T "PO"
+  tmux select-pane -t "ixv-management:0.1" -T "SM"
+  for i in {0..7}; do
+    tmux select-pane -t "ixv-dev:0.$i" -T "Dev$((i+1))"
+  done
+  tmux select-pane -t "ixv-qa:0.0" -T "QA1"
+  tmux select-pane -t "ixv-qa:0.1" -T "QA2"
+
   log "Sending role instructions..."
   tmux send-keys -t "ixv-management:0.0" "instructions/po.md を読んで役割を理解せよ。" Enter
   tmux send-keys -t "ixv-management:0.1" "instructions/sm.md を読んで役割を理解せよ。" Enter


### PR DESCRIPTION
## Summary
- フロントエンドの配色を黒ベースから白ベースに変更
- CSS変数とTailwindテーマ拡張による色の一元管理を導入
- coding-policy-ai-auditor準拠のgrayパレットを採用
- プライマリ（#3F61A7）、アクセント（#FFD32D）、ステータス色（success/warning/danger）を追加
- ターミナル内容の横オーバーフローを修正

## Changes
- `frontend/src/styles.css` - CSS変数による配色定義
- `frontend/tailwind.config.js` - Tailwindカスタムカラー設定
- `frontend/src/App.jsx` - セマンティックカラークラス適用
- `frontend/src/Events.jsx` - セマンティックカラークラス適用
- `frontend/src/TerminalStream.jsx` - セマンティックカラークラス適用 + overflow-x-auto追加
- `frontend/index.html` - body背景色クラス適用

## Test plan
- [x] フロントエンドをビルドしてエラーがないことを確認
- [x] ダッシュボードの配色が白ベースになっていることを確認
- [x] 選択状態やアニメーションが青色（primary）で表示されることを確認
- [x] ターミナル内容が横スクロール可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)