### PR TITLE
テンプレートファイルをgitignoreの除外対象外に設定

### DIFF
--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,5 +1,11 @@
-# エージェント作業記録
-queue/
+# エージェント作業記録（テンプレートは除外対象外）
+queue/*
+!queue/dashboard.md
+!queue/po_to_sm.yaml
+queue/reports/*
+!queue/reports/TEMPLATE.yaml
+queue/tasks/*
+!queue/tasks/dev.yaml
 
 # AI CLI設定
 .claude/

--- a/templates/queue/dashboard.md
+++ b/templates/queue/dashboard.md
@@ -1,0 +1,26 @@
+# IXV-Agents Dashboard
+
+## Sprint Info
+- Sprint: 0
+- Period: {{DATE}} ~ TBD
+- Goal: TBD
+
+## Backlog Status
+| Priority | ID | Summary | Status | Assignee |
+|----------|-----|---------|--------|----------|
+| - | - | - | - | - |
+
+## Agent Status
+| Agent | Current Task | Status | Last Update |
+|-------|--------------|--------|-------------|
+| PO | - | idle | - |
+| SM | - | idle | - |
+| Dev1 | - | idle | - |
+| Dev2 | - | idle | - |
+| Dev3 | - | idle | - |
+
+## Blockers
+- [ ] None
+
+## Notes
+- TBD


### PR DESCRIPTION
## Summary
- `.gitignore` の設定により `dashboard.md` が意図せず削除されていた問題を修正
- テンプレートファイル4つを除外対象外に明示指定し、今後の同様の問題を防止

## Test plan
- [ ] `git check-ignore templates/queue/dashboard.md` が出力なし（無視されていない）
- [ ] `git ls-files templates/queue/` で4ファイルが表示される

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)