### PR TITLE
Add project config files and fix CONSTITUTION.md typo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{sh,bash}]
+indent_size = 4
+
+[*.ps1]
+indent_size = 4
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+*.sh text eol=lf
+*.ps1 text eol=crlf
+*.md text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,21 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .env
+.env.local
+.env.*.local
+
+# IDE
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+Thumbs.db
+
+# Logs
+*.log
+.cache/
 
 # AI editor directories
 .claude/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: detect-private-key
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.22.1
+    hooks:
+      - id: gitleaks

--- a/templates/CONSTITUTION.md
+++ b/templates/CONSTITUTION.md
@@ -1,6 +1,6 @@
 <!--
 IMPORTANT:
-This file is a project Ccnstitution.
+This file is a project Constitution.
 Do NOT modify this file unless explicitly instructed.
 -->
 


### PR DESCRIPTION
## Summary

- Add `.editorconfig` for consistent formatting across editors
- Add `.gitattributes` for line ending consistency (LF for sh/md/yaml, CRLF for ps1)
- Add `.pre-commit-config.yaml` with YAML validation and secret scanning (gitleaks)
- Extend `.gitignore` with IDE, OS, and env patterns
- Fix typo "Ccnstitution" → "Constitution" in `templates/CONSTITUTION.md`

## Test plan

- [ ] Verify `.editorconfig` is recognized by IDE
- [ ] Verify `pre-commit install && pre-commit run --all-files` passes
- [ ] Verify `.gitattributes` line endings are correct on checkout

Closes #41, closes #43, closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)