### PR TITLE
Add CONTRIBUTING.md, SECURITY.md and standardize timestamp format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to IXV-Agents
+
+Thank you for your interest in contributing to IXV-Agents!
+
+## How to Contribute
+
+### Reporting Bugs
+
+- Use [GitHub Issues](https://github.com/elvezjp/ixv-agents/issues) to report bugs
+- Include steps to reproduce the issue
+- Specify your OS (macOS/Windows) and AI editor (OpenCode/Claude Code)
+
+### Submitting Pull Requests
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes
+4. Ensure scripts work on both macOS and Windows if applicable
+5. Submit a pull request
+
+### Code Style
+
+- **Shell scripts (.sh)**: Use `set -euo pipefail`, indent with 4 spaces
+- **PowerShell scripts (.ps1)**: Use `$ErrorActionPreference = "Stop"`, indent with 4 spaces
+- **Markdown (.md)**: Follow existing formatting conventions
+- **YAML (.yaml)**: Use 2-space indentation, ISO-8601 UTC timestamps (`YYYY-MM-DDTHH:MM:SSZ`)
+
+### Commit Messages
+
+- Use clear, descriptive commit messages
+- Reference issue numbers where applicable (e.g., `Closes #123`)
+
+## Development Setup
+
+See [README.md](README.md) for prerequisites and setup instructions.
+
+## Questions?
+
+- Open a [GitHub Issue](https://github.com/elvezjp/ixv-agents/issues) for questions
+- Contact: info@elvez.co.jp

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+- **Email**: info@elvez.co.jp
+- **Do NOT** open a public GitHub issue for security vulnerabilities
+
+We will acknowledge receipt within 3 business days and provide a timeline for a fix.
+
+## Security Design
+
+### Agent Role Boundaries
+
+- AI agents operate within defined role boundaries (PO, SM, Dev)
+- Writing to files outside an agent's role scope is prohibited
+- File ownership is enforced via the specification in `Spec.md`
+
+### Workspace Isolation
+
+- The `workspace/` directory is isolated from the repository root
+- AI editors cannot access tool READMEs or other unrelated files
+- Symlinks provide controlled access to `roles/` and `skills/` only
+
+### Traceability
+
+- All changes are traceable via `spec_ref`, `request_id`, and `task_id`
+- YAML-based communication provides an audit trail
+- Dashboard tracks agent status and task progress
+
+### Script Security
+
+- Shell scripts use `set -euo pipefail` for strict error handling
+- User inputs (e.g., model names) are validated before use
+- Process management uses exact-match patterns to avoid affecting unrelated processes
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest (main) | Yes |
+
+## Best Practices for Users
+
+- Only run IXV-Agents in trusted environments
+- Review AI-generated code before deploying to production
+- Keep AI editor tools (OpenCode, Claude Code) up to date
+- Do not store secrets in `workspace/` files

--- a/skills/dev-receive-task/SKILL.md
+++ b/skills/dev-receive-task/SKILL.md
@@ -105,8 +105,8 @@ queue/tasks/dev3.yaml  ← Dev3はこれだけ
 **queue/tasks/dev1.yaml**:
 ```yaml
 schema_version: "1.0"
-created_at: "2026-02-01T14:00:00"
-updated_at: "2026-02-01T14:00:00"
+created_at: "2026-02-01T14:00:00Z"
+updated_at: "2026-02-01T14:00:00Z"
 task_id: "TASK-20260201-010"
 spec_ref: README.md
 request_id: "REQ-20260201-004"
@@ -142,8 +142,8 @@ dependencies: []
 **queue/tasks/dev2.yaml**:
 ```yaml
 schema_version: "1.0"
-created_at: "2026-02-01T10:30:00"
-updated_at: "2026-02-01T10:30:00"
+created_at: "2026-02-01T10:30:00Z"
+updated_at: "2026-02-01T10:30:00Z"
 task_id: "TASK-20260201-001"
 spec_ref: README.md
 request_id: "REQ-20260201-003"

--- a/skills/dev-write-report/SKILL.md
+++ b/skills/dev-write-report/SKILL.md
@@ -95,8 +95,8 @@ issues:
 
 ```yaml
 schema_version: "1.0"
-created_at: "2026-02-01T15:30:00"
-updated_at: "2026-02-01T15:30:00"
+created_at: "2026-02-01T15:30:00Z"
+updated_at: "2026-02-01T15:30:00Z"
 task_id: "TASK-20260201-010"
 status: "done"
 summary: "認証APIエンドポイント（/auth/login, /auth/logout）の実装完了。全テストパス。"
@@ -114,8 +114,8 @@ issues: []
 
 ```yaml
 schema_version: "1.0"
-created_at: "2026-02-01T14:45:00"
-updated_at: "2026-02-01T14:45:00"
+created_at: "2026-02-01T14:45:00Z"
+updated_at: "2026-02-01T14:45:00Z"
 task_id: "TASK-20260201-011"
 status: "blocked"
 summary: "セッション管理の実装中にRedis接続エラーが発生。環境変数の設定が不足。"

--- a/skills/dev-write-report/SKILL.md
+++ b/skills/dev-write-report/SKILL.md
@@ -46,8 +46,8 @@ Spec.md 2.3.4 スキーマに準拠した YAML を生成する：
 
 ```yaml
 schema_version: "1.0"
-created_at: "YYYY-MM-DDTHH:MM:SS"
-updated_at: "YYYY-MM-DDTHH:MM:SS"
+created_at: "YYYY-MM-DDTHH:MM:SSZ"
+updated_at: "YYYY-MM-DDTHH:MM:SSZ"
 task_id: "TASK-YYYYMMDD-###"
 status: "done"
 summary: "200文字以内の結果概要"

--- a/skills/dev-write-report/references/report-yaml-schema.md
+++ b/skills/dev-write-report/references/report-yaml-schema.md
@@ -94,8 +94,8 @@ issues:
 
 ```yaml
 schema_version: "1.0"
-created_at: "YYYY-MM-DDTHH:MM:SS"
-updated_at: "YYYY-MM-DDTHH:MM:SS"
+created_at: "YYYY-MM-DDTHH:MM:SSZ"
+updated_at: "YYYY-MM-DDTHH:MM:SSZ"
 task_id: "TASK-YYYYMMDD-###"
 status: "done"
 summary: ""

--- a/skills/sm-write-task-yaml/SKILL.md
+++ b/skills/sm-write-task-yaml/SKILL.md
@@ -86,8 +86,8 @@ Spec.md 2.3.3 スキーマに準拠したYAMLを生成する。
 
 ```yaml
 schema_version: "1.0"
-created_at: "YYYY-MM-DDTHH:MM:SS"
-updated_at: "YYYY-MM-DDTHH:MM:SS"
+created_at: "YYYY-MM-DDTHH:MM:SSZ"
+updated_at: "YYYY-MM-DDTHH:MM:SSZ"
 task_id: "TASK-YYYYMMDD-###"
 spec_ref: README.md
 request_id: "REQ-YYYYMMDD-###"

--- a/skills/sm-write-task-yaml/SKILL.md
+++ b/skills/sm-write-task-yaml/SKILL.md
@@ -145,8 +145,8 @@ tmux send-keys -t ixv-agents:0.{N+1} Enter
 
 ```yaml
 schema_version: "1.0"
-created_at: "2026-02-01T10:30:00"
-updated_at: "2026-02-01T10:30:00"
+created_at: "2026-02-01T10:30:00Z"
+updated_at: "2026-02-01T10:30:00Z"
 task_id: "TASK-20260201-001"
 spec_ref: README.md
 request_id: "REQ-20260201-003"
@@ -168,8 +168,8 @@ dependencies: []
 **Dev1用** (`queue/tasks/dev1.yaml`):
 ```yaml
 schema_version: "1.0"
-created_at: "2026-02-01T14:00:00"
-updated_at: "2026-02-01T14:00:00"
+created_at: "2026-02-01T14:00:00Z"
+updated_at: "2026-02-01T14:00:00Z"
 task_id: "TASK-20260201-010"
 spec_ref: README.md
 request_id: "REQ-20260201-004"
@@ -191,8 +191,8 @@ dependencies: []
 **Dev2用** (`queue/tasks/dev2.yaml`):
 ```yaml
 schema_version: "1.0"
-created_at: "2026-02-01T14:00:00"
-updated_at: "2026-02-01T14:00:00"
+created_at: "2026-02-01T14:00:00Z"
+updated_at: "2026-02-01T14:00:00Z"
 task_id: "TASK-20260201-011"
 spec_ref: README.md
 request_id: "REQ-20260201-004"

--- a/skills/sm-write-task-yaml/references/task-yaml-schema.md
+++ b/skills/sm-write-task-yaml/references/task-yaml-schema.md
@@ -146,8 +146,8 @@ dependencies:
 
 ```yaml
 schema_version: "1.0"
-created_at: "YYYY-MM-DDTHH:MM:SS"
-updated_at: "YYYY-MM-DDTHH:MM:SS"
+created_at: "YYYY-MM-DDTHH:MM:SSZ"
+updated_at: "YYYY-MM-DDTHH:MM:SSZ"
 task_id: "TASK-YYYYMMDD-###"
 spec_ref: README.md
 request_id: "REQ-YYYYMMDD-###"


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with contribution guidelines, code style conventions, and commit message format
- Add `SECURITY.md` with vulnerability reporting process, security design documentation (role boundaries, workspace isolation, traceability), and best practices
- Standardize timestamp format to ISO-8601 UTC (`YYYY-MM-DDTHH:MM:SSZ`) in 4 YAML skill schema files that were missing the `Z` suffix

## Changed files

- `CONTRIBUTING.md` — new
- `SECURITY.md` — new
- `skills/dev-write-report/SKILL.md` — timestamp format fix
- `skills/sm-write-task-yaml/SKILL.md` — timestamp format fix
- `skills/dev-write-report/references/report-yaml-schema.md` — timestamp format fix
- `skills/sm-write-task-yaml/references/task-yaml-schema.md` — timestamp format fix

## Test plan

- [x] Verify CONTRIBUTING.md and SECURITY.md render correctly on GitHub
- [x] Verify timestamp format is consistent across all SKILL.md files

Closes #42, closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)