### PR TITLE
CI に shellcheck を追加する (refs #53)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
     rev: v8.30.0
     hooks:
       - id: gitleaks
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -19,14 +19,12 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 WORKSPACE_DIR="${ROOT_DIR}/workspace"
 cd "$ROOT_DIR"
 
-CLI_NAME="opencode"
 CLI_CMD="OPENCODE_PERMISSION='{\"permission\":{\"*\":\"allow\"}}' opencode"
 MODEL=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --claude-code)
-      CLI_NAME="claude"
       CLI_CMD="claude --dangerously-skip-permissions"
       shift
       ;;

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -12,7 +12,6 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$ROOT_DIR"
 
 # 色定義
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color


### PR DESCRIPTION
## Summary

- \`.pre-commit-config.yaml\` に \`shellcheck-py\` を追加。既存の CI 上の pre-commit ジョブが自動的に拾うため、\`.github/workflows/ci.yml\` への変更は不要。
- shellcheck が検出した SC2034（未使用変数）の警告を解消:
  - \`scripts/stop.sh\`: 未使用の \`RED\` を削除
  - \`scripts/boot.sh\`: 未使用の \`CLI_NAME\` を削除（同名変数への代入 2 箇所）

## Why

#53 の対応。過去 #34 で指摘されたシェルスクリプトの品質問題について、自動チェックが入っていなかったため再発防止策として shellcheck を CI に組み込む。

## shfmt について

#53 では shfmt 追加にも触れていますが、本PRでは見送りました。理由:

- \`boot.sh\` / \`stop.sh\` は 2 スペースインデント、\`setup_workspace.sh\` は 4 スペースインデントで不統一
- shfmt を入れるとどちらかに寄せる 300 行規模のフォーマット差分が発生し、本PR（CI設定）の変更意図が埋もれる
- インデントスタイルはチーム合意事項なので別途議論すべき

shfmt は #53 に残すか、別 Issue として切り出して対応するのが良さそうです。

## Test plan

- [x] ローカルで \`shellcheck scripts/*.sh\` が通ることを確認
- [x] ローカルで \`pre-commit run --all-files\` が全フックパスすることを確認
- [ ] GitHub Actions で pre-commit ジョブが shellcheck を実行しパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)